### PR TITLE
Small tweaks/fixes

### DIFF
--- a/exercises/geom-1/shaders/vertex.glsl
+++ b/exercises/geom-1/shaders/vertex.glsl
@@ -3,5 +3,5 @@ attribute vec3 position;
 uniform mat4 model, view, projection;
 
 void main() {
-  gl_Position = projection * view * vec4(position, 1);
+  gl_Position = projection * view * model * vec4(position, 1);
 }

--- a/exercises/geom-2/README.md
+++ b/exercises/geom-2/README.md
@@ -14,4 +14,10 @@ Translations are not linear in affine coordinates, however in projective homogen
 
 For this exercise, you will work out how to do this yourself.  That is, you should implement a GLSL function which constructs a 4x4 matrix representing a translation moving a point `p` to the origin. To get started modify the file `translate.glsl` <a href="/open/geom-2" target="_blank">in the directory for this lesson</a>.
 
-Note that GLSL matrices are stored in column major order, not row major as matrices are commonly written.  This means that the entries of the matrix are transposed with respect to the usual notation.
+Note that GLSL matrices are stored in *column major* order, not *row major* as matrices are commonly written.  This means that the entries of the matrix are transposed with respect to the usual notation.
+
+***
+
+## See Also
+
+* <a target="_blank" href="http://en.wikipedia.org/wiki/Translation_(geometry)" title="Translation (Wikipedia)">Translation (Wikipedia)</a>

--- a/exercises/geom-3/README.md
+++ b/exercises/geom-3/README.md
@@ -10,4 +10,10 @@ vec3 scaleVector(vec3 v, vec3 s) {
 }
 ```
 
-Like translation, scaling transformations are also linear in projective geometry. For this exercise, write a shader that computes a matrix representation of the scaling function above. To get started, a file called <a href="/open/geom-3" target="_blank">`scaling.glsl` has been created in this lesson's directory.</a>
+Like translation, scaling transformations are also linear in projective geometry. For this exercise, write a shader that computes a matrix representation of the scaling function above. To get started, a file called <a href="/open/geom-3" target="_blank">`scale.glsl` has been created in this lesson's directory.</a>
+
+***
+
+## See Also
+
+* <a target="_blank" href="http://en.wikipedia.org/wiki/Scaling_(geometry)" title="Scaling (Wikipedia)">Scaling (Wikipedia)</a>

--- a/exercises/intro-3/files/mandelbrot.glsl
+++ b/exercises/intro-3/files/mandelbrot.glsl
@@ -1,6 +1,7 @@
-bool mandelbrot(highp vec2 z) {
+bool mandelbrot(highp vec2 c) {
 
-  //Test if the point z is inside the mandelbrot set after 100 iterations
+  //Test if the point c is inside the mandelbrot set after 100 iterations
+  vec2 z = vec2(0.0);
 
   return false;
 }

--- a/exercises/light-1/files/vertex.glsl
+++ b/exercises/light-1/files/vertex.glsl
@@ -5,5 +5,5 @@ uniform mat4 model, view, projection;
 uniform vec3 ambient;
 
 void main() {
-  gl_Position = vec4(0,0,0,1);
+  gl_Position = position;
 }

--- a/exercises/light-2/files/vertex.glsl
+++ b/exercises/light-2/files/vertex.glsl
@@ -6,5 +6,5 @@ uniform mat4 inverseModel, inverseView, inverseProjection;
 uniform vec3 ambient, diffuse, lightDirection;
 
 void main() {
-  gl_Position = vec4(0,0,0,1);
+  gl_Position = position;
 }

--- a/exercises/light-3/files/vertex.glsl
+++ b/exercises/light-3/files/vertex.glsl
@@ -7,5 +7,5 @@ uniform vec3 ambient, diffuse, specular, lightDirection;
 uniform float shininess;
 
 void main() {
-  gl_Position = vec4(0,0,0,1);
+  gl_Position = position;
 }

--- a/exercises/light-4/files/vertex.glsl
+++ b/exercises/light-4/files/vertex.glsl
@@ -8,5 +8,5 @@ uniform vec3 ambient, diffuse, specular, lightPosition;
 uniform float shininess;
 
 void main() {
-  gl_Position = vec4(0,0,0,1);
+  gl_Position = position;
 }

--- a/exercises/light-5/files/vertex.glsl
+++ b/exercises/light-5/files/vertex.glsl
@@ -10,5 +10,5 @@ uniform vec3 ambient;
 uniform PointLight lights[4];
 
 void main() {
-  gl_Position = vec4(0,0,0,1);
+  gl_Position = position;
 }

--- a/exercises/vert-2/files/vertex.glsl
+++ b/exercises/vert-2/files/vertex.glsl
@@ -4,5 +4,5 @@ attribute vec4 position;
 attribute vec3 color;
 
 void main() {
-  gl_Position = vec4(0,0,0,1);
+  gl_Position = position;
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+var livePort  = Number(process.env.GLSLIFY_LIVE_PORT = 12491)
 var answers   = require('./lib/create-answers')
 var live      = require('glslify-live/server')
 var exercises = require('./exercises')
@@ -11,7 +12,6 @@ var path      = require('path')
 var url       = require('url')
 var fs        = require('fs')
 
-var livePort = Number(process.env.GLSLIFY_LIVE_PORT = 12491)
 var mainPort = 12492
 var closeWindow = fs.readFileSync(
   path.join(__dirname, 'lib/close-window.html')

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "a-big-triangle": "0.0.0",
+    "apprise": "^1.0.0",
     "autoprefixer": "^1.2.0",
     "baboon-image": "^1.0.0",
     "beefy": "^2.0.2",
@@ -53,6 +54,7 @@
     "opener": "^1.3.0",
     "quotemeta": "0.0.0",
     "raf": "^2.0.1",
+    "remove-element": "0.0.0",
     "rework": "^0.20.3",
     "rework-inline": "^0.2.0",
     "rework-npm": "^0.6.1",


### PR DESCRIPTION
- Use `position` attribute to prevent warnings in light exercises.
- Make variable names consistent with description in mandelbrot exercise.
- Add references for translation/scaling matrix exercises.
