### PR TITLE
update package.json with external links

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "Mikola Lysenko <mikolalysenko@gmail.com> (http://0fps.net)",
     "Chris Dickinson <chris@neversaw.us> (http://neversaw.us)"
   ],
+  "homepage": "http://nodeschool.io/#shader-school",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stackgl/shader-school.git"
+  },
   "license": "ISC",
   "dependencies": {
     "a-big-triangle": "0.0.0",


### PR DESCRIPTION
I couldn't find any references to GH / Nodeschool from NPM. As the NPM page is the first hit on Google, this might be nice to have.
