### PR TITLE
Use column-major ordering for rotation matrix.

### DIFF
--- a/exercises/10-vert-1/shaders/vertex.glsl
+++ b/exercises/10-vert-1/shaders/vertex.glsl
@@ -9,7 +9,7 @@ void main() {
   float c = cos(theta);
   float s = sin(theta);
 
-  mat2 rot = mat2(c, s, -s, c);
+  mat2 rot = mat2(c, -s, s, c);
 
   gl_Position = vec4(rot * position, 0, 1.0);
 }


### PR DESCRIPTION
This is a fix for #73, where the rotation matrix was not defined correctly.