### PR TITLE
26-gpgpu-3 : Wave Eqn : Descriptive text differs from Model answer

### DIFF
--- a/exercises/26-gpgpu-3/shaders/update.glsl
+++ b/exercises/26-gpgpu-3/shaders/update.glsl
@@ -21,7 +21,7 @@ void main() {
   float w = laplacian(coord);
   float p0 = state0(coord);
   float p1 = state1(coord);
-  float y = (1.0 - kdamping) * (kdiffuse * w  + 2.0 * p0 - p1);
+  float y = (1.0 - kdamping) * (kdiffuse * w  + 2.0 * p0) - p1;
 
   gl_FragColor = vec4(y,y,y,y);
 }


### PR DESCRIPTION
Update glsl to match README.md, which seems to have appropriate dimensions
Fixes issue #76

Hope this makes sense
Martin
:-)

PS: Without the change, the 'incorrect' version of the wave eqn also VERIFIES Ok, except that they can be seen to be different using the 'slider'.
