### PR TITLE
#24-gpgpu-1 : Game of Life fix

### DIFF
--- a/exercises/24-gpgpu-1/index.js
+++ b/exercises/24-gpgpu-1/index.js
@@ -114,7 +114,7 @@ function randomFill(width, height) {
   var i = 0
 
   while (i < data.length) {
-    data[i++] = Math.random() * 256
+    data[i++] = (Math.random()>.5)?255:0
     data[i++] = 0
     data[i++] = 0
     data[i++] = 1


### PR DESCRIPTION
The 'ideal solution' is a really neat 'logic compression'.  However, because the initial conditions are not {0,255}, it's almost impossible to write an explicit version that works.

The attached pull request changes the initial state to be {0,255} instead, so that the following kernel also works (boringly written, I know): 

```
float state(vec2 coord) {
  return texture2D(prevState, fract(coord / stateSize)).r;
}

void main() {
  vec2 coord = gl_FragCoord.xy;

  float count = state(coord+vec2(-1,-1)) + state(coord+vec2(-1, 0)) + state(coord+vec2(-1,+1)) + 
                state(coord+vec2( 0,-1)) +                          + state(coord+vec2( 0,+1)) + 
                state(coord+vec2(+1,-1)) + state(coord+vec2(+1, 0)) + state(coord+vec2(+1,+1));
  float current = state(coord);

  float s = (current==0.0 && count==3.0)?1.0:((current==1.0 && (count==2.0 || count==3.0))?1.0:0.0);

  gl_FragColor = vec4(s,s,s, 1.0);
}
```

All the Best
Martin
:-) 
