### PR TITLE
#25-GPGPU-2 : Heat eqn : Fixes issue #71 (kdamping, not kambient)

### DIFF
--- a/exercises/25-gpgpu-2/README.md
+++ b/exercises/25-gpgpu-2/README.md
@@ -4,7 +4,7 @@
 
 Implement a shader which computes a single step of the explicit Euler scheme for integrating the heat equation, described below.
 
-The previous state of `f(x,y,t-1)` will be encoded in a periodic texture. The diffusion constant and damping will be sent in the parameters `kdiffuse` and `kambient` respectively.
+The previous state of `f(x,y,t-1)` will be encoded in a periodic texture. The diffusion constant and damping will be sent in the parameters `kdiffuse` and `kdamping` respectively.
 
 To get started, there is a file called <a href="/open/25-gpgpu-2" target="_blank">`heat.glsl` in the directory for this lesson</a>.
 

--- a/exercises/25-gpgpu-2/README.md
+++ b/exercises/25-gpgpu-2/README.md
@@ -10,7 +10,7 @@ To get started, there is a file called <a href="/open/25-gpgpu-2" target="_blank
 
 ***
 
-The damped heat equation is a second order linear partial differential equation which describes the flow of heat through a material. In the continuous 2D setting it is described by the following equation:
+The damped heat equation is a second order linear partial differential equation which describes the flow of heat through a material.  In the continuous 2D setting it is described by the following equation:
 
 ```
      ( d^2 f   d^2 f )            d f
@@ -18,11 +18,11 @@ kD * ( ----- + ----- ) - kM * f = ---
      ( d x^2   d y^2 )            d t
 ```
 
-In this equation, `f(x,y,t)` is time evolving scalar field, representing the distribution of heat in the material. The parameter `kD` is the diffusion constant and controls the rate at which heat spreads, while `kM` is the damping factor which reprsents the rate at which heat is lost/gained. Equations of this sort are well studied in mechanics and engineering, and its solution has many applications.
+In this equation, `f(x,y,t)` is time evolving scalar field, representing the distribution of heat in the material.  The parameter `kD` is the diffusion constant and controls the rate at which heat spreads, while `kM` is the damping factor which represents the rate at which heat is lost/gained.  Equations of this sort are well studied in mechanics and engineering, and its solution has many applications.
 
 ## Euler integration
 
-One way to solve this equation is to discretize it and numerically integrate to obtain a solution. Without going too far into the details of how this works, supposing that `f(x,y,t)` is uniformly sampled on a unit grid, then the left hand side of the equation can be written using a stencil operation:
+One way to solve this equation is to discretize it and numerically integrate to obtain a solution.  Without going too far into the details of how this works, supposing that `f(x,y,t)` is uniformly sampled on a unit grid, then the left hand side of the equation can be written using a stencil operation:
 
 ```glsl
 float laplace(x, y) {
@@ -38,7 +38,7 @@ float laplace(x, y) {
 And with damping, the update rule for the integrator becomes:
 
 ```glsl
-nextState(x,y) = (1.0 - kDamping) * (
-  kDiffuse * laplace(x,y) + prevState(x,y)
+nextState(x,y) = (1.0 - kdamping) * (
+  kdiffuse * laplace(x,y) + prevState(x,y)
 )
 ```


### PR DESCRIPTION
As in the original Issue #71, the exercise text : 
```
The diffusion constant and damping will be sent in the parameters 
kdiffuse and kambient respectively.
```

didnt accurately reflect that one needs to add : 
```
uniform float kdiffuse, kdamping;
```

Fixed in the attached.
Martin
:-)
