### PR TITLE
fixed opener button & description links

### DIFF
--- a/exercises/frag-1/README.md
+++ b/exercises/frag-1/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Write a fragment shader which draws a disk of radius `128` centered at the point `vec2(256,256)` in device coordinates. The points inside the disk should be colored with `CIRCLE_COLOR` and the points outside should be colored with `OUTSIDE_COLOR`. To help get you started, a file called `fragment.glsl` has been created in <a href="/open/07-frag-1" target="_blank">this project's directory</a> to help get you started.
+Write a fragment shader which draws a disk of radius `128` centered at the point `vec2(256,256)` in device coordinates. The points inside the disk should be colored with `CIRCLE_COLOR` and the points outside should be colored with `OUTSIDE_COLOR`. To help get you started, a file called `fragment.glsl` has been created in <a href="/open/frag-1" target="_blank">this project's directory</a> to help get you started.
 
 ***
 

--- a/exercises/frag-2/README.md
+++ b/exercises/frag-2/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Create a shader which renders a checkerboard with 16x16 pixel tiles.  Tiles with even parity should be discarded, while tiles with odd parity should be drawn white. A template file called `fragment.glsl` has been created <a href="/open/08-frag-2" target="_blank">in this project's directory</a> to help get you started.
+Create a shader which renders a checkerboard with 16x16 pixel tiles.  Tiles with even parity should be discarded, while tiles with odd parity should be drawn white. A template file called `fragment.glsl` has been created <a href="/open/frag-2" target="_blank">in this project's directory</a> to help get you started.
 
 ***
 

--- a/exercises/frag-3/README.md
+++ b/exercises/frag-3/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Write a program which swaps the red and blue color channels of a texture image. To do this, you should modify the <a href="/open/09-frag-3" target="_blank">`fragment.glsl` shader in this project's directory</a>. You will be given the following uniforms to help compute this quantity:
+Write a program which swaps the red and blue color channels of a texture image. To do this, you should modify the <a href="/open/frag-3" target="_blank">`fragment.glsl` shader in this project's directory</a>. You will be given the following uniforms to help compute this quantity:
 
 * `screenSize` which should be applied to scale the coordinates of `gl_FragCoord` to an acceptable range.
 * `texture` which is a `sampler2D` containing the texture to draw.

--- a/exercises/geom-1/README.md
+++ b/exercises/geom-1/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-In this exercise, you will implement a vertex shader which applies the sequence of operations discussed below to a 3D vertex. Your vertex shader should take a `vec3` attribute called `position` and `mat4` uniforms called `model`, `view` and `projection`. To get started a vertex shader called `transforms.glsl` has been created <a href="/open/12-geom-1" target="_blank">in this project's directory</a>, which you should edit to create your solution.
+In this exercise, you will implement a vertex shader which applies the sequence of operations discussed below to a 3D vertex. Your vertex shader should take a `vec3` attribute called `position` and `mat4` uniforms called `model`, `view` and `projection`. To get started a vertex shader called `transforms.glsl` has been created <a href="/open/geom-1" target="_blank">in this project's directory</a>, which you should edit to create your solution.
 
 ***
 

--- a/exercises/geom-2/README.md
+++ b/exercises/geom-2/README.md
@@ -12,7 +12,7 @@ vec3 translatePoint(vec3 v, vec3 o) {
 
 Translations are not linear in affine coordinates, however in projective homogeneous coordinates they are.  As a result, they can be written as a matrix.  
 
-For this exercise, you will work out how to do this yourself.  That is, you should implement a GLSL function which constructs a 4x4 matrix representing a translation moving a point `p` to the origin. To get started modify the file `translate.glsl` <a href="/open/13-geom-2" target="_blank">in the directory for this lesson</a>.
+For this exercise, you will work out how to do this yourself.  That is, you should implement a GLSL function which constructs a 4x4 matrix representing a translation moving a point `p` to the origin. To get started modify the file `translate.glsl` <a href="/open/geom-2" target="_blank">in the directory for this lesson</a>.
 
 Note that GLSL matrices are stored in *column major* order, not *row major* as matrices are commonly written.  This means that the entries of the matrix are transposed with respect to the usual notation.
 

--- a/exercises/geom-3/README.md
+++ b/exercises/geom-3/README.md
@@ -10,7 +10,7 @@ vec3 scaleVector(vec3 v, vec3 s) {
 }
 ```
 
-Like translation, scaling transformations are also linear in projective geometry. For this exercise, write a shader that computes a matrix representation of the scaling function above. To get started, a file called <a href="/open/14-geom-3" target="_blank">`scale.glsl` has been created in this lesson's directory.</a>
+Like translation, scaling transformations are also linear in projective geometry. For this exercise, write a shader that computes a matrix representation of the scaling function above. To get started, a file called <a href="/open/geom-3" target="_blank">`scale.glsl` has been created in this lesson's directory.</a>
 
 ***
 

--- a/exercises/geom-4/README.md
+++ b/exercises/geom-4/README.md
@@ -10,4 +10,4 @@ vec3 reflectPoint(vec3 p, vec3 n) {
 }
 ```
 
-The above function is again linear in `p` so it can be translated into a matrix.  Do this now by modifying <a href="/open/15-geom-4" target="_blank">the file `reflect.glsl`</a> and writing a GLSL function to compute this quantity.
+The above function is again linear in `p` so it can be translated into a matrix.  Do this now by modifying <a href="/open/geom-4" target="_blank">the file `reflect.glsl`</a> and writing a GLSL function to compute this quantity.

--- a/exercises/geom-5/README.md
+++ b/exercises/geom-5/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Again, rotations are linear perspective transformations and so they can be written as matrices. For this exercise, you should translate the `rotatePoint` function below into a matrix. For the solution, <a href="/open/16-geom-5" target="_blank">modify the file `rotate.glsl` in this lesson's directory.</a>
+Again, rotations are linear perspective transformations and so they can be written as matrices. For this exercise, you should translate the `rotatePoint` function below into a matrix. For the solution, <a href="/open/geom-5" target="_blank">modify the file `rotate.glsl` in this lesson's directory.</a>
 
 ***
 

--- a/exercises/gpgpu-1/README.md
+++ b/exercises/gpgpu-1/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-In this [exercise's directory](/open/24-gpgpu-1) you'll find a file called `life.glsl`. Modify this file to create a fragment shader that implements Conway's game of life.
+In this [exercise's directory](/open/gpgpu-1) you'll find a file called `life.glsl`. Modify this file to create a fragment shader that implements Conway's game of life.
 
 The fragment shader will be executed once per cell. Output vec4(1,1,1,1) if the cell is on, otherwise vec4(0,0,0,1) if the cell is off. The previous state of the world is stored in the sampler `prevState` and the size of the state buffer passed in the uniform `stateSize`.
 

--- a/exercises/gpgpu-2/README.md
+++ b/exercises/gpgpu-2/README.md
@@ -6,7 +6,7 @@ Implement a shader which computes a single step of the explicit Euler scheme for
 
 The previous state of `f(x,y,t-1)` will be encoded in a periodic texture. The diffusion constant and damping will be sent in the parameters `kdiffuse` and `kambient` respectively.
 
-To get started, there is a file called <a href="/open/25-gpgpu-2" target="_blank">`heat.glsl` in the directory for this lesson</a>.
+To get started, there is a file called <a href="/open/gpgpu-2" target="_blank">`heat.glsl` in the directory for this lesson</a>.
 
 ***
 

--- a/exercises/gpgpu-3/README.md
+++ b/exercises/gpgpu-3/README.md
@@ -4,7 +4,7 @@
 
 Implement a fragment shader which computes the the next state by explicit Euler integration.
 
-The previous state is stored in the texture `prevState[0]` and the previous-previous state is in `prevState[1]`. To help get started, a <a href="/open/26-gpgpu-3" target="_blank">template file called `wave.glsl` has been created in the directory for this lesson</a>.
+The previous state is stored in the texture `prevState[0]` and the previous-previous state is in `prevState[1]`. To help get started, a <a href="/open/gpgpu-3" target="_blank">template file called `wave.glsl` has been created in the directory for this lesson</a>.
 
 <span class="warn">**WARNING:**</span> This lesson requires the floating point texture extension. If your GPU/browser do not support this, then this lesson will not work.
 

--- a/exercises/intro-0/README.md
+++ b/exercises/intro-0/README.md
@@ -4,7 +4,7 @@
 
 Each exercise has its own directory preloaded with shaders for you to edit.
 Generally, there will be
-<a href="/open/00-intro-0" target="_blank">a link like this one</a> that *will
+<a href="/open/intro-0" target="_blank">a link like this one</a> that *will
 open that directory for you*. If the link does not work for you, you can find
 the files for each exercise in the `answers/` directory.
 

--- a/exercises/intro-1/README.md
+++ b/exercises/intro-1/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-In <a href="/open/01-intro-1" target="_blank">this lesson's directory</a> you'll
+In <a href="/open/intro-1" target="_blank">this lesson's directory</a> you'll
 find a file called `hello.glsl` that exports a function called `sum`. Fix this
 function to return the sum of its first two arguments.
 

--- a/exercises/intro-2/README.md
+++ b/exercises/intro-2/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Write a function to compute the side lengths of a right triangle, given the angle for one of the sides and the length of the hypotenuse. To help you get started, a template file called `sides.glsl` has been created in <a href="/open/02-intro-2" target="_blank">the directory for this lesson</a>.
+Write a function to compute the side lengths of a right triangle, given the angle for one of the sides and the length of the hypotenuse. To help you get started, a template file called `sides.glsl` has been created in <a href="/open/intro-2" target="_blank">the directory for this lesson</a>.
 
 ***
 

--- a/exercises/intro-3/README.md
+++ b/exercises/intro-3/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-In this lesson, you will write a GLSL function which computes the unit angle bisector between two vectors.  That is, it is the vector whose length is `1` and whose angle is halfway between two vectors.  If the vectors are parallel or zero, you can return whatever you want. A file called <a href="/open/03-intro-3">`vectors.glsl` has been created for you as a template</a>.
+In this lesson, you will write a GLSL function which computes the unit angle bisector between two vectors.  That is, it is the vector whose length is `1` and whose angle is halfway between two vectors.  If the vectors are parallel or zero, you can return whatever you want. A file called <a href="/open/intro-3">`vectors.glsl` has been created for you as a template</a>.
 
 As an example, if `a = vec2(1,0)` and `b = vec2(0,1)`, then you should return the result `vec2(sqrt(2)/2, sqrt(2)/2)`.
 

--- a/exercises/intro-4/README.md
+++ b/exercises/intro-4/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-In this exercise write a subroutine to test if a point is contained in a bounding box defined by a pair of upper and lower bounds. A template file called `box.glsl` has been created <a href="/open/04-intro-4" target="_blank">in the directory for this purpose</a>.
+In this exercise write a subroutine to test if a point is contained in a bounding box defined by a pair of upper and lower bounds. A template file called `box.glsl` has been created <a href="/open/intro-4" target="_blank">in the directory for this purpose</a>.
 
 ***
 

--- a/exercises/intro-5/README.md
+++ b/exercises/intro-5/README.md
@@ -31,7 +31,7 @@ bool mandelbrotConverges(vec2 z) {
 }
 ```
 
-The Mandelbrot set is the collection of all points which do not diverge. Write a function which given a test point `c` tests if after 100 iterations it is still inside the Mandelbrot set.  To get started, a <a href="/open/05-intro-5">file `mandelbrot.glsl` has been created in this project's directory.</a>
+The Mandelbrot set is the collection of all points which do not diverge. Write a function which given a test point `c` tests if after 100 iterations it is still inside the Mandelbrot set.  To get started, a <a href="/open/intro-5">file `mandelbrot.glsl` has been created in this project's directory.</a>
 
 ***
 

--- a/exercises/intro-6/README.md
+++ b/exercises/intro-6/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Write a function to raise a 2x2 matrix `m` to the nth power, where 0 <= n < 16 is an integer. To get started, edit the template <a href="/open/06-intro-6" target="_blank">file `mpow.glsl` in the directory for this project</a>.
+Write a function to raise a 2x2 matrix `m` to the nth power, where 0 <= n < 16 is an integer. To get started, edit the template <a href="/open/intro-6" target="_blank">file `mpow.glsl` in the directory for this project</a>.
 
 ***
 

--- a/exercises/light-1/README.md
+++ b/exercises/light-1/README.md
@@ -4,7 +4,7 @@
 
 As a warm up, we will start with the very simplest lighting model, which is called "flat shading".  In flat shading, the light reflected from any surface to the detector is assumed to be constant. That is, there is some parameter called `kA` which just determines the color of each fragment.
 
-<a href="/open/17-light-1" target="_blank">The files `vertex.glsl` and `fragment.glsl` have been provided</a> as well as the appropriate uniform and attribute variables for the camera.  Apply the model, view and projection transformation matrices as in the `GEOM 1` exercise.
+<a href="/open/light-1" target="_blank">The files `vertex.glsl` and `fragment.glsl` have been provided</a> as well as the appropriate uniform and attribute variables for the camera.  Apply the model, view and projection transformation matrices as in the `GEOM 1` exercise.
 
 ***
 

--- a/exercises/light-2/README.md
+++ b/exercises/light-2/README.md
@@ -19,7 +19,7 @@ Implement a shader which renders a 3D object using Lambertian diffuse lighting. 
 
 #### Notes
 
-To implement your shader, modify the `vertex.glsl` and `fragment.glsl` files <a href="/open/18-light-2" target="_blank">in this lesson's directory</a>.
+To implement your shader, modify the `vertex.glsl` and `fragment.glsl` files <a href="/open/light-2" target="_blank">in this lesson's directory</a>.
 
 ***
 

--- a/exercises/light-3/README.md
+++ b/exercises/light-3/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Implement the Phong lighting model in GLSL.  To get started, a vertex and fragment shader have been created in <a href="/open/19-light-3" target="_blank">the directory for this lesson</a>.  The input to these shaders will be as follows:
+Implement the Phong lighting model in GLSL.  To get started, a vertex and fragment shader have been created in <a href="/open/light-3" target="_blank">the directory for this lesson</a>.  The input to these shaders will be as follows:
 
 ### Attributes
 

--- a/exercises/light-4/README.md
+++ b/exercises/light-4/README.md
@@ -4,7 +4,7 @@
 
 In this exercise, generalize the Phong lighting shader from the previous lesson to support point light sources.  The `lightDirection` uniform has been replaced by a new uniform called `lightPosition`.
 
-<a href="/open/20-light-4" target="_blank">Template files have been created in the directory for this lesson</a>, though you may find it expedient to copy your work from the previous directory.
+<a href="/open/light-4" target="_blank">Template files have been created in the directory for this lesson</a>, though you may find it expedient to copy your work from the previous directory.
 
 ***
 

--- a/exercises/light-5/README.md
+++ b/exercises/light-5/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Modify the point light shader from the previous lesson to support multiple light sources. <a href="/open/21-light-5" target="_blank">Template files for this purpose have been created in the directory for this lesson.</a> The file `light.glsl` is used to define the datatype of the light values.  Use these parameters to apply multiple phong lighting contributions in the shader.
+Modify the point light shader from the previous lesson to support multiple light sources. <a href="/open/light-5" target="_blank">Template files for this purpose have been created in the directory for this lesson.</a> The file `light.glsl` is used to define the datatype of the light values.  Use these parameters to apply multiple phong lighting contributions in the shader.
 
 ***
 

--- a/exercises/npr-1/README.md
+++ b/exercises/npr-1/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Modify the Lambert diffuse lighting model from `LIGHT 2` to support cel shading.  The shader will be passed an extra uniform called `numBands` which determines the number of levels the light intensity should be quantized to.  To get started, <a href="/open/22-npr-1" target="_blank">modify the template files in this directory</a>.
+Modify the Lambert diffuse lighting model from `LIGHT 2` to support cel shading.  The shader will be passed an extra uniform called `numBands` which determines the number of levels the light intensity should be quantized to.  To get started, <a href="/open/npr-1" target="_blank">modify the template files in this directory</a>.
 
 ***
 

--- a/exercises/npr-2/README.md
+++ b/exercises/npr-2/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-In this exercise, you will implement the two color version of Gooch shading. To get you started, <a href="/open/23-npr-2" target="_blank">a template vertex and fragment shader has been created in the directory for this project</a>.  These shaders will be passed the following parameters:
+In this exercise, you will implement the two color version of Gooch shading. To get you started, <a href="/open/npr-2" target="_blank">a template vertex and fragment shader has been created in the directory for this project</a>.  These shaders will be passed the following parameters:
 
 ### Attributes
 

--- a/exercises/playground-gpgpu/README.md
+++ b/exercises/playground-gpgpu/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-There is no exercise for this lesson!  Play with the shaders and have fun!  The files for this module are stored in the <a href="/open/playground">answers/playground</a> directory.
+There is no exercise for this lesson!  Play with the shaders and have fun!  The files for this module are stored in the <a href="/open/playground-gpgu">answers/playground</a> directory.
 
 ***
 

--- a/exercises/prims-1/README.md
+++ b/exercises/prims-1/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Create a vertex/fragment shader pair to render a collection of colored point sprites. <a href="/open/27-prims-1" target="_blank">A pair of starting shaders have been created in the directory for this lesson to help get started.</a> These shaders get a standard collection of camera matrices factored into the model/view/projection transformations.  In addition, the shaders also get 3 attributes:
+Create a vertex/fragment shader pair to render a collection of colored point sprites. <a href="/open/prims-1" target="_blank">A pair of starting shaders have been created in the directory for this lesson to help get started.</a> These shaders get a standard collection of camera matrices factored into the model/view/projection transformations.  In addition, the shaders also get 3 attributes:
 
 * `position` which is the position of each point sprite
 * `color` which is the color of each point sprite

--- a/exercises/prims-2/README.md
+++ b/exercises/prims-2/README.md
@@ -2,7 +2,7 @@
 
 ## Exercise
 
-Write a fragment shader which colors fragments depending on their relative orientation to the view direction. If they are facing away from the camera, color them with `backColor`, or if they are facing towards the camera color them with `frontColor`.  To get started, a <a href="/open/28-prims-2" target="_blank">template file `fragment.glsl` has been created for you.</a>
+Write a fragment shader which colors fragments depending on their relative orientation to the view direction. If they are facing away from the camera, color them with `backColor`, or if they are facing towards the camera color them with `frontColor`.  To get started, a <a href="/open/prims-2" target="_blank">template file `fragment.glsl` has been created for you.</a>
 
 ***
 

--- a/exercises/vert-1/README.md
+++ b/exercises/vert-1/README.md
@@ -7,7 +7,7 @@ For this exercise you will write a shader which applies a 2D rotation to a verte
 * A `vec2` attribute called `position` representing the position of the vertices in the plane
 * A `float` uniform `theta` encoding the amount to rotate by in radians
 
-Edit the file called <a href="/open/10-vert-1" target="_blank">`vertex.glsl` in the directory of this project</a>.
+Edit the file called <a href="/open/vert-1" target="_blank">`vertex.glsl` in the directory of this project</a>.
 
 ***
 

--- a/exercises/vert-2/README.md
+++ b/exercises/vert-2/README.md
@@ -6,7 +6,7 @@ In this exercise you will write a minimal vertex shader and fragment shader for 
 
 Specifically, you should declare a vertex shader with two attributes: `position` and `color`.  Your fragment shader should output the value of `color` to the `gl_FragColor` register, which will be automatically interpolated.  This will be used to draw a shaded triangle.
 
-To get you started, a template vertex and fragment shader have been created in <a href="/open/11-vert-2" target="_blank">the directory for this lesson</a>.
+To get you started, a template vertex and fragment shader have been created in <a href="/open/vert-2" target="_blank">the directory for this lesson</a>.
 
 Hint : The triangles' 3 corners are the only vertices used, so you (a) need to figure out their coordinates, and (b) construct an expression that colors each vertex correctly.  
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,10 @@ function createServer(root) {
       }
 
       if (paths[0] === 'open') {
-        opener(path.join(root, paths[1]))
+        var exPath = exmap[paths[1]]
+        if (exPath) {
+          opener(path.join(root, exPath))
+        }
         return res.end(closeWindow)
       }
 


### PR DESCRIPTION
The opener button:
![image](https://cloud.githubusercontent.com/assets/1074881/4433279/2df3e4f0-46cd-11e4-95d3-dd4765694c48.png)
has been broken ever since https://github.com/stackgl/shader-school/pull/98.

This PR fixes it and also removes the hardcoded numeric prefixes from each exercise's readmes.
