### PR TITLE
Upgrade Browserify to ^6.3.2, fixes #58 & #68

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "beefy": "^2.0.2",
     "brfs": "^1.1.1",
     "browser-menu": "^0.1.0",
-    "browserify": "^4.1.10",
+    "browserify": "^6.3.2",
     "canvas-fit": "0.0.0",
     "chalk": "^0.4.0",
     "clamp": "^1.0.0",


### PR DESCRIPTION
I've confirmed this working on Windows 7 + Chrome.
