### PR TITLE
fix typo and add uniforms to gpgpu-2

### DIFF
--- a/exercises/gpgpu-2/README.md
+++ b/exercises/gpgpu-2/README.md
@@ -4,7 +4,7 @@
 
 Implement a shader which computes a single step of the explicit Euler scheme for integrating the heat equation, described below.
 
-The previous state of `f(x,y,t-1)` will be encoded in a periodic texture. The diffusion constant and damping will be sent in the parameters `kdiffuse` and `kambient` respectively.
+The previous state of `f(x,y,t-1)` will be encoded in a periodic texture. The diffusion constant and damping will be sent in the parameters `kdiffuse` and `kdamping` respectively.
 
 To get started, there is a file called <a href="/open/gpgpu-2" target="_blank">`heat.glsl` in the directory for this lesson</a>.
 

--- a/exercises/gpgpu-2/files/heat.glsl
+++ b/exercises/gpgpu-2/files/heat.glsl
@@ -2,6 +2,8 @@ precision mediump float;
 
 uniform sampler2D prevState;
 uniform vec2 stateSize;
+uniform float kdiffuse;
+uniform float kdamping;
 
 float state(vec2 x) {
   return texture2D(prevState, fract(x / stateSize)).r;
@@ -10,7 +12,7 @@ float state(vec2 x) {
 void main() {
   vec2 coord = gl_FragCoord.xy;
 
-  //TODO: Compute next state using a 5-point Laplacian stencil and the rule 
+  //TODO: Compute next state using a 5-point Laplacian stencil and the rule
 
   float y = state(coord);
 


### PR DESCRIPTION
Lesson **gpgpu-2** erroneously refers to the `kdamping` uniform as `kambient` and neither uniform existed in the `heat.glsl` shader as in previous lessons.


Thanks for all of your hard work!