### PR TITLE
No negative diffuse shading

### DIFF
--- a/exercises/light-3/shaders/fragment.glsl
+++ b/exercises/light-3/shaders/fragment.glsl
@@ -9,7 +9,7 @@ void main() {
   vec3 normal = normalize(fragNormal);
   vec3 light = normalize(lightDirection);
   
-  float lambert = dot(normal, light);
+  float lambert = max(dot(normal, light), 0.0);
   float phong = pow(max(dot(reflect(light, normal), eyeDirection), 0.0), shininess);
 
   vec3 lightColor = ambient + diffuse * lambert + specular * phong;


### PR DESCRIPTION
The clamping on the lambert factor from the previous exercise (https://github.com/stackgl/shader-school/blob/master/exercises/light-2/shaders/fragment.glsl) wasn't done in this one.

(as a side effect, there's no way I could have passed without cheating - both outputs look pretty similar)