### PR TITLE
Changed `code` text to more readable color

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -68,7 +68,7 @@ body .gl-compare-sidebar {
 }
 
 .gl-compare-content code {
-  color: #AAA;
+  color: #FFE169;
 }
 
 .gl-compare-content pre > code {


### PR DESCRIPTION
It might be my lack-luster monitor, but why is there grey on grey text for all the `code` sections of the readme's? I personally changed the color on mine to not have to keep highlighting the text to read it. Also I picked #FFE169 because it is the yellow color used for everything else and matches the color scheme.