### PR TITLE
Fix inconsistency for lighting

### DIFF
--- a/exercises/npr-1/shaders/vertex.glsl
+++ b/exercises/npr-1/shaders/vertex.glsl
@@ -15,7 +15,7 @@ varying vec3 fragNormal;
 
 void main() {
   vec4 worldPosition = model * vec4(position, 1.0);
-  vec4 worldNormal = vec4(normal, 0.0) * inverseModel;
+  vec4 worldNormal = vec4(normal, 0.0) * inverseModel * inverseView;
 
   gl_Position = projection * view * worldPosition;
   fragNormal = worldNormal.xyz;


### PR DESCRIPTION
Since the lesson description for NPR 01 tells us to work off of LIGHT 02, the vertex shaders should match.

This just applies changes in 51e75d7558ee096c1a3f1198e88b326f8e25f6b4 to NPR 01.