### PR TITLE
Fix buffer initialization for wave equation exercise

### DIFF
--- a/exercises/gpgpu-2/index.js
+++ b/exercises/gpgpu-2/index.js
@@ -61,14 +61,14 @@ var shaders = {
         frag: process.env.file_heat_glsl
       , vert: './shaders/pass-thru.glsl'
     })(gl),
-    buffers: createStateBuffers(2)
+    buffers: createStateBuffers(numBuffers)
   },
   expected: {
     logic: createShader({
         frag: './shaders/update.glsl'
       , vert: './shaders/pass-thru.glsl'
     })(gl),
-    buffers: createStateBuffers(2)
+    buffers: createStateBuffers(numBuffers)
   }
 }
 

--- a/exercises/gpgpu-3/index.js
+++ b/exercises/gpgpu-3/index.js
@@ -61,14 +61,14 @@ var shaders = {
         frag: process.env.file_wave_glsl
       , vert: './shaders/pass-thru.glsl'
     })(gl),
-    buffers: createStateBuffers(2)
+    buffers: createStateBuffers(numBuffers)
   },
   expected: {
     logic: createShader({
         frag: './shaders/update.glsl'
       , vert: './shaders/pass-thru.glsl'
     })(gl),
-    buffers: createStateBuffers(2)
+    buffers: createStateBuffers(numBuffers)
   }
 }
 


### PR DESCRIPTION
It looks like exercise gpgpu-3 requires a total of three buffers (one front and two back for the two previous states), but currently only two buffers are being created. I think the original author intended to use the `numBuffers` variable, which is set to 3, but accidently hardcoded 2 in the `createStateBuffers` call.

`numBuffers` was also declared but unused in the heat equation example, so I also updated that for consistency.